### PR TITLE
Update default radius value in shape docs

### DIFF
--- a/docs/funcs.md
+++ b/docs/funcs.md
@@ -194,7 +194,7 @@ Pixelate texture with `pixelX` segments and `pixelY` segments.
 
 ### shape( `sides`, `radius`, `smoothing`)
 * sides :: int (default 3.0)
-* radius :: float (default 60.0)
+* radius :: float (default 0.3)
 * smoothing :: float (default 0.01)
 
 ### solid( `r`, `g`, `b`, `a`)


### PR DESCRIPTION
I've just started playing around with Hydra - lots of fun!
Tried out the shape command and noticed that writing the (apparently) default radius value of 60 renders a shape larger than the canvas, so I just get a blank white screen.

I noticed that according to https://github.com/ojack/hydra-synth/commit/39f7cd783ccccfda7b30888b6c26c794dfff7516#diff-e4cce30f8d436e76187a26beb75e4fdfR86
the default value for radius is apparently 0.3, so I have updated the hydra docs accordingly.
(Let me know if my assumption is incorrect!)