### PR TITLE
Changed the Ctrl-Shift-H behavior to also hide the menu bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Go to https://hydra-editor-v1.glitch.me
 * CTRL-Enter: run a line of code
 * CTRL-Shift-Enter: run all code on screen
 * ALT-Enter: run a block
-* CTRL-Shift-H: hide or show code
+* CTRL-Shift-H: hide or show code and menu
 * CTRL-Shift-S: Save screenshot and download as local file
 
 All code can be run either from the in-browser text editor or from the browser console.

--- a/hydra-server/app/src/editor.js
+++ b/hydra-server/app/src/editor.js
@@ -29,16 +29,21 @@ var EditorClass = function () {
         self.shareSketch()
       },
       'Shift-Ctrl-H': function (instance) {
-        var l = document.getElementsByClassName('CodeMirror-scroll')[0]
-        if (isShowing) {
-          l.style.opacity = 0
-          self.logElement.style.opacity  = 0
-          isShowing = false
-        } else {
-          l.style.opacity= 1
-          self.logElement.style.opacity  = 1
-          isShowing = true
-        }
+        // NOTE here's where the hide function is.
+        var l = []
+        l.push(document.getElementsByClassName('CodeMirror-scroll')[0])
+        l.push(document.getElementById('modal-header'))
+        l.forEach(function(item, i, a) {
+          if (isShowing) {
+            item.style.opacity = 0
+            self.logElement.style.opacity  = 0
+          } else {
+            item.style.opacity= 1
+            self.logElement.style.opacity  = 1
+          }
+          // last element of the array
+          if (i == a.length - 1) { isShowing = !isShowing }
+        })
       },
       'Ctrl-Enter': function (instance) {
         var c = instance.getCursor()


### PR DESCRIPTION
I didn't open this as an issue, or discuss it with @ojack ahead of time. Let me know if you're prefer these sort of unsolicited ideas to be vetted ahead of time in a different way, rather than just receiving a pull request without context.

*What is the change?* The ctrl-shift-h behavior now hides the menu toolbar as well as the code window.

*Why do this?* I would like to create one window as the receiver and one window as the code editor. I agree with statements @ojack made in an interview that seeing the code is part of the aesthetic, but I like having the option of only seeing the output of the code as well.

*Where is the change?* I added the additional hide in the same place as the original hide. Now it just finds both elements and sets them to `opacity 0`.

I've tested this on up-to-date Chrome and seen no issues. I haven't tested on other browsers.

*Not Hidden*
<img width="1440" alt="Screenshot 2019-04-29 13 47 53" src="https://user-images.githubusercontent.com/64711/56922451-748b6d80-6a85-11e9-9dac-c12aa0423b40.png">

*Hidden*
<img width="1439" alt="Screenshot 2019-04-29 13 48 09" src="https://user-images.githubusercontent.com/64711/56922474-83722000-6a85-11e9-8c9a-4f44c875629f.png">

*Using one instance without code / menu to display a second instance...using one screen to edit code, the other to display*
<img width="1697" alt="Screenshot 2019-04-29 14 00 57" src="https://user-images.githubusercontent.com/64711/56923278-663e5100-6a87-11e9-95fc-46a131784195.png">


