### PR TITLE
Support external mirror windows

### DIFF
--- a/hydra-server/app/src/menu.js
+++ b/hydra-server/app/src/menu.js
@@ -12,6 +12,7 @@ class Menu {
     this.clearButton =  document.getElementById("clear-icon")
     this.shareButton =  document.getElementById("share-icon")
     this.shuffleButton = document.getElementById("shuffle-icon")
+    this.externalButton = document.getElementById("external-icon")
     this.editorText = document.getElementsByClassName('CodeMirror-scroll')[0]
 
     this.shuffleButton.onclick = this.shuffleSketches.bind(this)
@@ -24,10 +25,31 @@ class Menu {
         this.openModal()
       }
     }
+    this.externalButton.onclick = this.createExternal.bind(this)
 
     this.isClosed = false
     this.closeModal()
   }
+
+
+  createExternal() {
+      var stream = document.getElementById('hydra-canvas').captureStream()
+      var external = window.open('external.html', '_blank', 'toolbar=0,location=0,menubar=0')
+
+      // Give the external page time to load or it won't find the video.
+      setTimeout(() => {
+        var externalVideo = external.document.getElementById("canvas-mirror")
+        externalVideo.srcObject = stream
+        externalVideo.play()
+        var externalCodeHolder = external.document.getElementById("code-holder")
+        var originalCodeHolder = document.getElementById('code-holder')
+
+        // Mirror code from main to external
+        setInterval(() => {
+          externalCodeHolder.innerHTML = originalCodeHolder.innerHTML
+        }, 100)
+      }, 500)
+    }
 
   shuffleSketches() {
     this.clearAll()

--- a/hydra-server/public/css/external.css
+++ b/hydra-server/public/css/external.css
@@ -1,0 +1,8 @@
+video {
+  width: 100vw;
+  height: 100vh;
+  position: absolute;
+  top: 0;
+  left: 0;
+  object-fit: cover;
+}

--- a/hydra-server/public/external.html
+++ b/hydra-server/public/external.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>&lt; hydra[external] &gt;</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="./css/codemirror.css">
+  <link rel="stylesheet" href="./css/tomorrow-night-eighties.css">
+  <link rel="stylesheet" href="./css/external.css">
+</head>
+<body>
+	<video autoplay muted id="canvas-mirror"></video>
+	<form id="code-holder"></form>
+</body>

--- a/hydra-server/public/index.html
+++ b/hydra-server/public/index.html
@@ -40,6 +40,7 @@
       <div id="modal-header">
         <div><!--<i class="fas fa-bars icon"></i>--></div>
         <div>
+          <i id="external-icon" title="open external mirror window" class="fas fa-external-link-alt icon" aria-hidden="true"></i>
           <i id="share-icon" title="upload to gallery" class="fas fa-upload icon" aria-hidden="true"></i>
           <i id="clear-icon" title="clear all" class="fa fa-trash icon" aria-hidden="true"></i>
           <i id="shuffle-icon" title="show random sketch" class="fas fa-random icon" aria-hidden="true"></i>


### PR DESCRIPTION
When I perform live, move between video inputs etc, I'd like to be able to do all of that comfortably on a laptop screen with Hydra open; while also having Hydra open on an external screen, showing both my code and the generated canvas.

This PR adds a button that creates a second window, streams code changes and the canvas into it, that can be used on a second screen for this use case.

I haven't yet tested if it this method of streaming develops lag (I suspect it might; as I noticed some audio-reactive stuff doesn't seem to land on time in a video playback of a show I did with this)