### PR TITLE
add a hot key to format editor code with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Go to https://hydra-editor.glitch.me
 * CTRL-Shift-Enter: run all code on screen
 * ALT-Enter: run a block
 * CTRL-Shift-H: hide or show code
+* CTRL-Shift-F: format code using [Prettier](https://prettier.io/)
 * CTRL-Shift-S: Save screenshot and download as local file
 * CTRL-Shift-G: Share to twitter (if available). Shares to [@hydra_patterns](https://twitter.com/hydra_patterns)
 

--- a/hydra-server/app/keymaps.js
+++ b/hydra-server/app/keymaps.js
@@ -21,6 +21,12 @@ module.exports = {
             menu.shareSketch()
           }
 
+          // shift - ctrl - F: format code
+          if (e.keyCode === 70) {
+            e.preventDefault()
+            menu.formatCode()
+          }
+
           // shift - ctrl - l: save to url
           if(e.keyCode === 76) {
             e.preventDefault()

--- a/hydra-server/app/src/menu.js
+++ b/hydra-server/app/src/menu.js
@@ -1,5 +1,6 @@
 const repl = require('./repl.js')
-
+const prettier = require("prettier/standalone")
+const parserBabel = require("prettier/parser-babel");
 
 class Menu {
   constructor (obj) {
@@ -46,6 +47,14 @@ class Menu {
     this.sketches.setRandomSketch()
     this.editor.setValue(this.sketches.code)
     repl.eval(this.editor.getValue())
+  }
+
+  formatCode() {
+    this.editor.setValue(prettier.format(this.editor.getValue(), {
+      parser: "babel",
+      plugins: [parserBabel],
+      printWidth: 50
+    }))
   }
 
   shareSketch() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.0.1",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1295,7 +1295,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1313,11 +1314,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1330,15 +1333,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1441,7 +1447,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1451,6 +1458,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1463,17 +1471,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1490,6 +1501,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1562,7 +1574,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1572,6 +1585,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1647,7 +1661,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1677,6 +1692,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1694,6 +1710,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1732,11 +1749,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -4955,6 +4974,11 @@
           }
         }
       }
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
     },
     "process": {
       "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "multer": "^1.4.1",
     "nedb": "^1.8.0",
     "p5": "^0.6.1",
+    "prettier": "^2.0.5",
     "raf-loop": "^1.1.3",
     "rtc-patch-bay": "^1.0.0",
     "simple-peer": "^9.1.2",


### PR DESCRIPTION
code formatting shouldn't be the worry of someone who is live coding, the code formatting should actually help them live code!

this PR adds the hot key `control + shift + f` to format the code in the editor with [Prettier](https://prettier.io/). 

here is a .gif example of how this would work:
![Kapture 2020-05-07 at 0 46 38](https://user-images.githubusercontent.com/1582620/81268062-47f52480-8ffc-11ea-8d6b-3ef8a5661c10.gif)

happy to talk about some sensible defaults (like `printWidth`) as well at finding the right hot key ☺️ 

hope this helps people code live!

