### PR TITLE
Add support for CMD/Meta key in place of CTRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Go to https://hydra-editor.glitch.me
 * CTRL-Shift-S: Save screenshot and download as local file
 * CTRL-Shift-G: Share to twitter (if available). Shares to [@hydra_patterns](https://twitter.com/hydra_patterns)
 
+For macOS users, CMD/Meta can be used in place of CTRL
+
 All code can be run either from the in-browser text editor or from the browser console.
 
 Check [@hydra_patterns](https://twitter.com/hydra_patterns) for patterns folks have shared as an easy way to get started.

--- a/hydra-server/app/keymaps.js
+++ b/hydra-server/app/keymaps.js
@@ -2,7 +2,7 @@ module.exports = {
   init : ({ editor, gallery, menu, repl, log}) => {
     window.onkeydown = (e) => {
     //  console.log(e)
-      if ( e.ctrlKey === true ) {
+      if ( e.ctrlKey === true || e.metaKey === true ) {
         if ( e.shiftKey === true ) {
           console.log(e)
           // shift - ctrl - enter: evalAll


### PR DESCRIPTION
I really struggle to get used to using control key on Mac when almost everything else uses the command key in its place.

It makes it more comfortable for me to use, but there might be something I've missed that makes this not a good idea. Happy for feedback!