### PR TITLE
Solve image not loading on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hydra
-![hydra](https://github.com/ojack/hydra/blob/master/hydra-3-01.png?raw=true)
+![hydra](https://github.com/ojack/hydra/blob/main/hydra-3-01.png?raw=true)
 
 Set of tools for livecoding networked visuals. Inspired by analog modular synthesizers, these tools are an exploration into using streaming over the web for routing video sources and outputs in realtime.
 


### PR DESCRIPTION
Renames the branch name in the image source on the README to the correct branch being used.

Which is now main and no longer master.

This makes the image load properly on the README.