### PR TITLE
Fix broken link to hydra-synth file

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ MIDI controllers can work with Hydra via WebMIDI an example workflow is at [/doc
 
 There is an updated list of functions at [/docs/funcs.md](https://github.com/ojack/hydra/blob/master/docs/funcs.md).
 
-As well as in the [source code for hydra-synth](https://github.com/ojack/hydra-synth/blob/master/src/composable-glsl-functions.js).
+As well as in the [source code for hydra-synth](https://github.com/ojack/hydra-synth/blob/master/src/glsl/glsl-functions.js).
 
 #### Changelog between v0 and v1:
 * Syntax change from 'o0.osc()' to 'osc().out(o0)'. Note: old syntax still works


### PR DESCRIPTION
It took me a second to sort through the name changes in the `hydra-synth` repo to make sure I could find the right file, so I figured I would save some time for somebody else later!