### PR TITLE
Fix 'p5 is not defined' error

### DIFF
--- a/hydra-server/public/index.html
+++ b/hydra-server/public/index.html
@@ -13,8 +13,8 @@
  <meta name="twitter:description" content="live coding networked visuals in the browser">
  <meta name="twitter:image" content="https://cdn.glitch.com/9c3a06ab-0731-42ca-a1a3-3a249825d08f%2FScreen%20Shot%202018-06-24%20at%204.47.49%20PM.png?1531889983803">
  <meta name="twitter:card" content="summary_large_image">
- <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.min.js" defer async></script>
- <script src="./bundle.min.js?1.2.12ajk" defer async></script> 
+ <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.min.js" defer></script>
+ <script src="./bundle.min.js?1.2.12ajk" defer></script> 
  <link href="https://fonts.googleapis.com/css?family=Chivo:300,400,700" rel="stylesheet"> 
 <link rel="stylesheet" href="./css/fontawesome.css">
   <link rel="stylesheet" href="./css/codemirror.css">


### PR DESCRIPTION
Hi

I tried to run the code with `npm run start` but got the following error in the console and hydra failed to load: `Uncaught ReferenceError: p5 is not defined`

I think this is because `async` does not guarantee the order of the scripts to be loaded, so bundle.js was executed before p5.js was loaded. I removed the `async` keyword and everything worked again.