### PR TITLE
Add toggle fullscreen button to UI

### DIFF
--- a/frontend/web-editor/src/store.js
+++ b/frontend/web-editor/src/store.js
@@ -110,9 +110,29 @@ module.exports = function store(state, emitter) {
 
   })
 
-  emitter.on('view:fullscreen', function(){
-    document.documentElement.requestFullscreen();
+  // toggle fullscreen
+  emitter.on('view:toggle-fullscreen', function() {
+
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else {
+      document.documentElement.requestFullscreen()
+    }
   });
+
+  addEventListener("fullscreenchange", function() {
+    // render UI again after fullscreen change
+    state.fullscreen = document.fullscreenElement
+    emitter.emit('render');
+  });
+
+  // disable resize button when full screen comes from browser and not UI.
+  addEventListener("resize", function() {
+    state.browserFullscreen =
+      window.innerHeight == screen.height &&
+      !document.fullscreenElement
+    emitter.emit('render');
+  })
 }
 
 function showConfirmation(successCallback, terminateCallback) {

--- a/frontend/web-editor/src/store.js
+++ b/frontend/web-editor/src/store.js
@@ -109,6 +109,10 @@ module.exports = function store(state, emitter) {
   emitter.on('mutate sketch', function () {
 
   })
+
+  emitter.on('view:fullscreen', function(){
+    document.documentElement.requestFullscreen();
+  });
 }
 
 function showConfirmation(successCallback, terminateCallback) {

--- a/frontend/web-editor/src/views/toolbar.js
+++ b/frontend/web-editor/src/views/toolbar.js
@@ -14,6 +14,7 @@ module.exports = function toolbar(state, emit) {
         ${icon("clear", `fa fa-trash ${hidden}`, "clear all", 'editor:clearAll')}
         ${icon("shuffle", `fa-random`, "show random sketch", 'gallery:showExample')}
         ${icon("mutator", `fa-dice ${hidden}`, "make random change", 'editor:randomize')}
+        ${icon("fullscreen", `fa-expand ${hidden}`, "go fullscreen", 'view:fullscreen')}
         ${icon("close", state.showInfo? "fa-times" : "fa-question-circle", "", 'toggle info')}
     </div>`
 }

--- a/frontend/web-editor/src/views/toolbar.js
+++ b/frontend/web-editor/src/views/toolbar.js
@@ -1,7 +1,8 @@
 const html = require('choo/html')
 
 module.exports = function toolbar(state, emit) {
-    const hidden = state.showInfo ? 'hidden' : ''
+    const hidden = state.showInfo ? 'hidden' : '';
+    const fullscreenHidden = state.browserFullscreen? 'hidden' : '';
 
     const dispatch = (eventName) => (e) => emit(eventName, e)
 
@@ -14,7 +15,12 @@ module.exports = function toolbar(state, emit) {
         ${icon("clear", `fa fa-trash ${hidden}`, "clear all", 'editor:clearAll')}
         ${icon("shuffle", `fa-random`, "show random sketch", 'gallery:showExample')}
         ${icon("mutator", `fa-dice ${hidden}`, "make random change", 'editor:randomize')}
-        ${icon("fullscreen", `fa-expand ${hidden}`, "go fullscreen", 'view:fullscreen')}
+        ${icon("fullscreen",
+            state.fullscreen? `fa-compress`: `fa-expand`
+            + ` ${hidden}`
+            + ` ${fullscreenHidden}`,
+            "toggle fullscreen",
+            'view:toggle-fullscreen')}
         ${icon("close", state.showInfo? "fa-times" : "fa-question-circle", "", 'toggle info')}
     </div>`
 }


### PR DESCRIPTION
Adding a toggle full screen button to hydra UI.

It aims to improve usability, and enable full screen in devices such as smartphones, where full screen can not be enabled directly from the browser.